### PR TITLE
Temporary hide the grid while taking screenshot

### DIFF
--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -2,6 +2,7 @@ let camera = null;
 let scene = null;
 let orbitControl = null;
 let prevStore = [];
+let gridHelper = null;
 
 function SceneManager(canvas) {
 
@@ -24,7 +25,7 @@ function SceneManager(canvas) {
 
   function buildScene() {
     const scene = new THREE.Scene();
-    const gridHelper = new THREE.PolarGridHelper(300, 10);
+    gridHelper = new THREE.PolarGridHelper(300, 10);
     scene.add(gridHelper);
 
     return scene;
@@ -106,10 +107,21 @@ function SceneManager(canvas) {
 
   this.takeScreenshot = function () {
     var a = document.createElement('a');
+    gridHelper.visible = false;
     renderer.setClearColor( 0x000000, 0 );
-    a.href = renderer.domElement.toDataURL("image/png", "image/octet-stream");
-    a.download = 'JustSketchMe - Screenshot.png'
-    a.click();
+
+    // Hide the grid temporarily before taking the screenshot
+    setTimeout(function () {
+      a.href = renderer.domElement.toDataURL("image/png", "image/octet-stream");
+      a.download = 'JustSketchMe - Screenshot.png'
+      a.click();
+
+      // Show grid again
+      setTimeout(function () {
+        gridHelper.visible = true;
+      }, 50);
+    }, 10);
+    
   }
 
   this.increaseAmbientLightIntensity = function () {


### PR DESCRIPTION
Hi, as a hacktoberfest participant I was searching for fun projects to hack, and found the justsketchme repo. One thing that I noticed was that the grid was visible in the screenshots. Perhaps thats intensional, but I thought I could try with a PR anyway since I had already experimented and found one solution. I don't have any experience from three.js and perhaps there is a better solution than using a timeout to postpone the screenshot for a refreshed rendered frame. I bet there is a better solution for that in three.js, but I have not yet taken my time to read the documentation. I normally code in playcanvas.com from the company I work for http://www.animech.com

The only touched file is SceneManager.js

Hopefully this will be an accepted PR or at least not flagged as spam :-)